### PR TITLE
Fix locale-dependent decimal formatting crashes in result tables

### DIFF
--- a/src/main/java/PDVCLI/PDVCLIMainClass.java
+++ b/src/main/java/PDVCLI/PDVCLIMainClass.java
@@ -1,6 +1,7 @@
 package PDVCLI;
 
 import PDVCLI.utils.AddInformationPanel;
+import PDVGUI.utils.DecimalFormats;
 import PDVGUI.fileimport.MSOneImport;
 import PDVGUI.fileimport.MzXMLScanImport;
 import PDVGUI.gui.PDVMainClass;
@@ -960,7 +961,7 @@ public class PDVCLIMainClass extends JFrame {
 
             annotations = spectrumAnnotator.getSpectrumAnnotationFiter(annotationPreferences, specificAnnotationSettings, mSnSpectrum, peptideAssumption.getPeptide(), null, ptmFactory, true);
 
-            DecimalFormat df = new DecimalFormat("#.00");
+            DecimalFormat df = DecimalFormats.create("#.00");
 
             Double allMatchInt = 0.0;
             Double allPeakInt = 0.0;

--- a/src/main/java/PDVGUI/fileimport/FragePipeImport.java
+++ b/src/main/java/PDVGUI/fileimport/FragePipeImport.java
@@ -2,6 +2,7 @@ package PDVGUI.fileimport;
 
 import PDVGUI.DB.SQLiteConnection;
 import PDVGUI.gui.PDVMainClass;
+import PDVGUI.utils.DecimalFormats;
 import com.compomics.util.experiment.biology.NeutralLoss;
 import com.compomics.util.experiment.biology.PTM;
 import com.compomics.util.experiment.biology.PTMFactory;
@@ -96,7 +97,7 @@ public class FragePipeImport {
     /**
      * Decimal
      */
-    DecimalFormat df = new DecimalFormat("####0.000");
+    DecimalFormat df = DecimalFormats.create("####0.000");
 
     /**
      * Main constructor

--- a/src/main/java/PDVGUI/fileimport/MSOneImport.java
+++ b/src/main/java/PDVGUI/fileimport/MSOneImport.java
@@ -121,7 +121,7 @@ public class MSOneImport {
 
                     rtRange = chromatogram.getRtRange();
 
-                    detailsList.add("LC gradient length/t/"+String.format("%.0f",rtRange.lowerEndpoint())+" - "+String.format("%.0f",rtRange.upperEndpoint())+" min");
+                    detailsList.add(String.format(Locale.US, "LC gradient length/t/%.0f - %.0f min", rtRange.lowerEndpoint(), rtRange.upperEndpoint()));
                 }
 
                 for (MsScan msScan : msScans) {
@@ -165,7 +165,7 @@ public class MSOneImport {
                 }
 
                 keyToRtAndInt.put("TIC", rtToItem);
-                detailsList.add("LC gradient length/t/"+String.format("%.0f",startRT)+" - "+String.format("%.0f",endRT)+" min");
+                detailsList.add(String.format(Locale.US, "LC gradient length/t/%.0f - %.0f min", startRT, endRT));
 
                 //detailsList.add("RT (min)/t/Start:" + startRT +" End:" + endRT);
             }

--- a/src/main/java/PDVGUI/fileimport/MzIDFileImport.java
+++ b/src/main/java/PDVGUI/fileimport/MzIDFileImport.java
@@ -2,6 +2,7 @@ package PDVGUI.fileimport;
 
 import PDVGUI.DB.SQLiteConnection;
 import PDVGUI.gui.PDVMainClass;
+import PDVGUI.utils.DecimalFormats;
 import com.compomics.util.experiment.biology.AminoAcidSequence;
 import com.compomics.util.experiment.biology.NeutralLoss;
 import com.compomics.util.experiment.biology.PTM;
@@ -106,7 +107,7 @@ public class MzIDFileImport {
     /**
      * Decimal
      */
-    DecimalFormat df = new DecimalFormat("####0.000");
+    DecimalFormat df = DecimalFormats.create("####0.000");
 
     /**
      * Constructor

--- a/src/main/java/PDVGUI/fileimport/PepXMLFileImport.java
+++ b/src/main/java/PDVGUI/fileimport/PepXMLFileImport.java
@@ -2,6 +2,7 @@ package PDVGUI.fileimport;
 
 import PDVGUI.DB.SQLiteConnection;
 import PDVGUI.gui.PDVMainClass;
+import PDVGUI.utils.DecimalFormats;
 import com.compomics.util.experiment.biology.*;
 import com.compomics.util.experiment.identification.matches.ModificationMatch;
 import com.compomics.util.experiment.identification.matches.SpectrumMatch;
@@ -124,11 +125,11 @@ public class PepXMLFileImport {
     /**
      * For PTNProphet
      */
-    DecimalFormat massDF = new DecimalFormat("#.0000");
+    DecimalFormat massDF = DecimalFormats.create("#.0000");
     /**
      * For crux modification mass
      */
-    DecimalFormat cruxDF = new DecimalFormat("#.00");
+    DecimalFormat cruxDF = DecimalFormats.create("#.00");
     /**
      * Spectrum ID to spectrum number
      */

--- a/src/main/java/PDVGUI/gui/utils/SpectrumMainPanel.java
+++ b/src/main/java/PDVGUI/gui/utils/SpectrumMainPanel.java
@@ -3,6 +3,7 @@ package PDVGUI.gui.utils;
 import PDVGUI.gui.*;
 import PDVGUI.gui.utils.Export.ExportExpectedSizeDialog;
 import PDVGUI.gui.utils.Export.ExportMGFDialog;
+import PDVGUI.utils.DecimalFormats;
 import com.compomics.util.experiment.biology.*;
 import com.compomics.util.experiment.biology.ions.PeptideFragmentIon;
 import com.compomics.util.experiment.biology.ions.TagFragmentIon;
@@ -1564,7 +1565,7 @@ public class SpectrumMainPanel extends JPanel {
                     spectrumPanel.showAnnotatedPeaksOnly(!annotationSettings.showAllPeaks());
                     spectrumPanel.setYAxisZoomExcludesBackgroundPeaks(false);
 
-                    DecimalFormat df = new DecimalFormat("#.00");
+                    DecimalFormat df = DecimalFormats.create("#.00");
 
                     Double allMatchInt = 0.0;
                     Double allPeakInt = 0.0;

--- a/src/main/java/PDVGUI/gui/utils/TableModel/DatabaseTableModel.java
+++ b/src/main/java/PDVGUI/gui/utils/TableModel/DatabaseTableModel.java
@@ -10,6 +10,7 @@ import com.compomics.util.experiment.identification.spectrum_assumptions.Peptide
 import com.compomics.util.experiment.massspectrometry.MSnSpectrum;
 import com.compomics.util.experiment.massspectrometry.Precursor;
 import com.compomics.util.experiment.massspectrometry.SpectrumFactory;
+import PDVGUI.utils.DecimalFormats;
 import umich.ms.datatypes.scan.IScan;
 import umich.ms.datatypes.scan.props.PrecursorInfo;
 import umich.ms.datatypes.scancollection.impl.ScanCollectionDefault;
@@ -52,7 +53,7 @@ public class DatabaseTableModel extends DefaultTableModel {
     /**
      * Decimal format
      */
-    private DecimalFormat df = new DecimalFormat("#.0000");
+    private DecimalFormat df = DecimalFormats.create("#.0000");
     /**
      * Is new soft or not
      */

--- a/src/main/java/PDVGUI/gui/utils/TableModel/DeNovoTableModel.java
+++ b/src/main/java/PDVGUI/gui/utils/TableModel/DeNovoTableModel.java
@@ -7,6 +7,7 @@ import com.compomics.util.experiment.identification.spectrum_assumptions.TagAssu
 import com.compomics.util.experiment.massspectrometry.MSnSpectrum;
 import com.compomics.util.experiment.massspectrometry.Precursor;
 import com.compomics.util.experiment.massspectrometry.SpectrumFactory;
+import PDVGUI.utils.DecimalFormats;
 
 import javax.swing.table.DefaultTableModel;
 import java.text.DecimalFormat;
@@ -38,7 +39,7 @@ public class DeNovoTableModel extends DefaultTableModel {
     /**
      * Decimal format
      */
-    private DecimalFormat df = new DecimalFormat("#.0000");
+    private DecimalFormat df = DecimalFormats.create("#.0000");
     /**
      * Spectrum key to selected
      */

--- a/src/main/java/PDVGUI/gui/utils/TableModel/FrageTableModel.java
+++ b/src/main/java/PDVGUI/gui/utils/TableModel/FrageTableModel.java
@@ -5,6 +5,7 @@ import com.compomics.util.experiment.identification.matches.SpectrumMatch;
 import com.compomics.util.experiment.identification.spectrum_assumptions.PeptideAssumption;
 import com.compomics.util.experiment.massspectrometry.MSnSpectrum;
 import com.compomics.util.experiment.massspectrometry.Precursor;
+import PDVGUI.utils.DecimalFormats;
 
 import javax.swing.table.DefaultTableModel;
 import java.text.DecimalFormat;
@@ -28,7 +29,7 @@ public class FrageTableModel extends DefaultTableModel {
     /**
      * Decimal format
      */
-    private DecimalFormat df = new DecimalFormat("#.0000");
+    private DecimalFormat df = DecimalFormats.create("#.0000");
     /**
      * Spectrum key to selected
      */

--- a/src/main/java/PDVGUI/utils/DecimalFormats.java
+++ b/src/main/java/PDVGUI/utils/DecimalFormats.java
@@ -1,0 +1,18 @@
+package PDVGUI.utils;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+/**
+ * Creates decimal formats for file formats and numeric UI values.
+ */
+public final class DecimalFormats {
+
+    private DecimalFormats() {
+    }
+
+    public static DecimalFormat create(String pattern) {
+        return new DecimalFormat(pattern, DecimalFormatSymbols.getInstance(Locale.US));
+    }
+}

--- a/src/main/java/PDVGUI/utils/Export.java
+++ b/src/main/java/PDVGUI/utils/Export.java
@@ -88,7 +88,7 @@ public class Export {
     private static void exportExceptedFormatPic(File exportFile, ImageType imageType, SVGGraphics2D svgGraphics2D)
             throws IOException, TranscoderException {
 
-        DecimalFormat df = new DecimalFormat("#.000000");
+        DecimalFormat df = DecimalFormats.create("#.000000");
 
         if (new File(exportFile.getAbsolutePath() + ".temp").exists()) {
             new File(exportFile.getAbsolutePath() + ".temp").delete();

--- a/src/main/java/PDVGUI/utils/ExportReports.java
+++ b/src/main/java/PDVGUI/utils/ExportReports.java
@@ -243,7 +243,7 @@ public class ExportReports {
                 throw new UnsupportedOperationException("Operation not supported for spectrumIdentificationAssumption of type " + spectrumIdentificationAssumption.getClass() + ".");
             }
 
-            DecimalFormat df = new DecimalFormat("#.00");
+            DecimalFormat df = DecimalFormats.create("#.00");
 
             Double allMatchInt = 0.0;
             Double allPeakInt = 0.0;


### PR DESCRIPTION
This PR fixes a locale-dependent decimal formatting bug that can crash PDV result table rendering when the JVM default locale uses a comma as decimal separator.

PDV currently formats numeric values with DecimalFormat, then in several places parses the formatted string back with Double.valueOf(...). Under locales such as German, French, Dutch/Belgian, etc., `DecimalFormat("#.0000").format(8.6407)` returns `8,6407`, but `Double.valueOf("8,6407")` throws `NumberFormatException`.

This was observed while opening InstaNovo results in PDV 2.4.0, but the root cause is not specific to InstaNovo. The same pattern exists in shared table models and other import/export/display paths.

##  Steps To Reproduce

  1. Start PDV 2.4.0 with a locale that uses comma decimal separators, for example:

```bash
java -Duser.language=de -Duser.country=DE -jar PDV-2.4.0.jar
```

  2. Open the De Novo import dialog.
  3. Select an InstaNovo CSV result file, for example: [`SF_200217_U2OS_TiO2_HCD_OT_rep1.full.mzml.instanovo-1.2.2.transformer.model-instanovo-v1.2.0.denovo.greedy.beams-1.normalized-columns.csv`](https://zenodo.org/records/20756892/files/SF_200217_U2OS_TiO2_HCD_OT_rep1.full.mzml.instanovo-1.2.2.transformer.model-instanovo-v1.2.0.denovo.greedy.beams-1.normalized-columns.csv)
  4. Select the corresponding spectrum file [`SF_200217_U2OS_TiO2_HCD_OT_rep1.mzML`](http://pdv.zhang-lab.org/data/download/test_data/msdata/SF_200217_U2OS_TiO2_HCD_OT_rep1.mzML.gz)
  5. Load the results.

##  Observed Behavior

PDV shows an empty error dialog

<img width="1857" height="1049" alt="Screenshot From 2026-06-19 09-50-55" src="https://github.com/user-attachments/assets/c71b494e-aa74-44d6-bef8-6d7b5c1620f6" />

and logs repeated table rendering exceptions like:

```
java.lang.NumberFormatException: For input string: "8,6407"
      at java.lang.Double.valueOf(Double.java:755)
      at PDVGUI.gui.utils.TableModel.DatabaseTableModel.getValueAt(DatabaseTableModel.java:344)
      at PDVGUI.gui.utils.TableModel.DatabaseTableModel.getColumnClass(DatabaseTableModel.java:480)
```

##  Expected Behavior

PDV should load and render result tables correctly regardless of the user’s JVM/system locale.

##  Fix

This PR adds a shared DecimalFormats helper that creates DecimalFormat instances with locale-independent decimal symbols using Locale.US.

It updates the affected GUI table models, importers, exporters, spectrum display, and CLI formatting code to use this helper. It also updates remaining numeric String.format(...) calls to pass Locale.US explicitly.

##  Validation

  - Verified under `Locale.GERMANY ` that:
      - default `DecimalFormat("#.0000")` produces `8,6407`
      - the new helper produces `8.6407`
      - `Double.valueOf("8.6407")` succeeds
